### PR TITLE
fix to UnboundLocalError when callable name passed to memoize decorator

### DIFF
--- a/diskcache/memo.py
+++ b/diskcache/memo.py
@@ -61,6 +61,8 @@ def memoize(cache, name=None, typed=False, expire=None, tag=None):
 
     def decorator(function):
         "Decorator created by memoize call for callable."
+        reference = name
+
         if name is None:
             try:
                 reference = function.__qualname__

--- a/tests/test_fanout.py
+++ b/tests/test_fanout.py
@@ -525,7 +525,7 @@ def test_memoize(cache):
 
         return alpha
 
-    @cache.memoize()
+    @cache.memoize(name='callable_name')
     def fibrec(num):
         if num == 0:
             return 0


### PR DESCRIPTION
When name parameter is provided to memoize decorator then  
`UnboundLocalError: local variable 'reference' referenced before assignment` happens. So I attempted to fix it.