### PR TITLE
allow creating an index on top of an existing cache

### DIFF
--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -341,7 +341,11 @@ class EmptyDirWarning(UserWarning):
     pass
 
 
-class Cache(object):
+class BaseCache(object):
+    '''A common class from which all cache types inherit.'''
+
+
+class Cache(BaseCache):
     "Disk and file backed cache."
     # pylint: disable=bad-continuation
     def __init__(self, directory, timeout=60, disk=Disk, **settings):

--- a/diskcache/fanout.py
+++ b/diskcache/fanout.py
@@ -5,12 +5,12 @@ import os.path as op
 import sqlite3
 import time
 
-from .core import ENOVAL, DEFAULT_SETTINGS, Cache, Disk, Timeout
+from .core import ENOVAL, DEFAULT_SETTINGS, BaseCache, Cache, Disk, Timeout
 from .memo import memoize
 from .persistent import Deque, Index
 
 
-class FanoutCache(object):
+class FanoutCache(BaseCache):
     "Cache that shards keys and values."
     def __init__(self, directory, shards=8, timeout=0.010, disk=Disk,
                  **settings):


### PR DESCRIPTION
this allows the first argument to Index to be an existing cache, in
which case the Index will use that rather than creating a new Cache.

Let me know if you think this is reasonable and I will add some tests for the
change.