### PR TITLE
Disk.filename now takes unused key, value params

### DIFF
--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -186,12 +186,13 @@ class Disk(object):
             return pickle.load(BytesIO(key))
 
 
-    def store(self, value, read):
+    def store(self, value, read, key=None):
         """Convert `value` to fields size, mode, filename, and value for Cache
         table.
 
         :param value: value to convert
         :param bool read: True when value is file-like object
+        :param key: key for item. Can be None.
         :return: (size, mode, filename, value) tuple for Cache table
 
         """
@@ -208,14 +209,14 @@ class Disk(object):
             if len(value) < min_file_size:
                 return 0, MODE_RAW, None, sqlite3.Binary(value)
             else:
-                filename, full_path = self.filename()
+                filename, full_path = self.filename(key, value)
 
                 with open(full_path, 'wb') as writer:
                     writer.write(value)
 
                 return len(value), MODE_BINARY, filename, None
         elif type_value is TextType:
-            filename, full_path = self.filename()
+            filename, full_path = self.filename(key, value)
 
             with io_open(full_path, 'w', encoding='UTF-8') as writer:
                 writer.write(value)
@@ -225,7 +226,7 @@ class Disk(object):
         elif read:
             size = 0
             reader = ft.partial(value.read, 2 ** 22)
-            filename, full_path = self.filename()
+            filename, full_path = self.filename(key, value)
 
             with open(full_path, 'wb') as writer:
                 for chunk in iter(reader, b''):
@@ -239,7 +240,7 @@ class Disk(object):
             if len(result) < min_file_size:
                 return 0, MODE_PICKLE, None, sqlite3.Binary(result)
             else:
-                filename, full_path = self.filename()
+                filename, full_path = self.filename(key, value)
 
                 with open(full_path, 'wb') as writer:
                     writer.write(result)
@@ -279,7 +280,7 @@ class Disk(object):
                 return pickle.load(BytesIO(value))
 
 
-    def filename(self):
+    def filename(self, key=None, value=None):
         """Return filename and full-path tuple for file storage.
 
         Filename will be a randomly generated 28 character hexadecimal string
@@ -287,6 +288,8 @@ class Disk(object):
         reduce the size of directories. On older filesystems, lookups in
         directories with many files are slow.
 
+        :param key: key for item. Ignored by default implementation. Can be None.
+        :param value: value for item. Ignored by default implementation.
         """
         hex_name = codecs.encode(os.urandom(16), 'hex').decode('utf-8')
         sub_dir = op.join(hex_name[:2], hex_name[2:4])
@@ -569,7 +572,7 @@ class Cache(object):
         now = time.time()
         db_key, raw = self._disk.put(key)
         expire_time = None if expire is None else now + expire
-        size, mode, filename, db_value = self._disk.store(value, read)
+        size, mode, filename, db_value = self._disk.store(value, read, key=key)
         columns = (expire_time, tag, size, mode, filename, db_value)
 
         # The order of SELECT, UPDATE, and INSERT is important below.
@@ -746,7 +749,7 @@ class Cache(object):
         now = time.time()
         db_key, raw = self._disk.put(key)
         expire_time = None if expire is None else now + expire
-        size, mode, filename, db_value = self._disk.store(value, read)
+        size, mode, filename, db_value = self._disk.store(value, read, key=key)
         columns = (expire_time, tag, size, mode, filename, db_value)
 
         with self._transact(filename) as (sql, cleanup):
@@ -809,7 +812,7 @@ class Cache(object):
                     raise KeyError(key)
 
                 value = default + delta
-                columns = (None, None) + self._disk.store(value, False)
+                columns = (None, None) + self._disk.store(value, False, key=key)
                 self._row_insert(db_key, raw, now, columns)
                 self._cull(now, sql, cleanup)
                 return value
@@ -821,7 +824,7 @@ class Cache(object):
                     raise KeyError(key)
 
                 value = default + delta
-                columns = (None, None) + self._disk.store(value, False)
+                columns = (None, None) + self._disk.store(value, False, key=key)
                 self._row_update(rowid, now, columns)
                 self._cull(now, sql, cleanup)
                 cleanup(filename)


### PR DESCRIPTION
This allows Disk subclasses to allow for discoverable names based on key, value, md5, etc. when writing files to disk.
Disk.store has an incompatible signature change, however, in that it now needs to accept key arguments.

This could be fixed by having calls to `store`  first attempt with the `key=key` param, but catch `TypeError` and fall back to calling without the `key` param. I'm fine implementing either; not sure what your philosophy is on breaking changes like this.

Also, let me know how you feel about the test coverage.