### PR TITLE
Add __bool__ / __nonzero__ to cache classes

### DIFF
--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -1817,6 +1817,14 @@ class Cache(object):
         return self.reset('count')
 
 
+    def __bool__(self):
+        # Always True, implemented to prevent fallback to __len__
+        return True
+
+
+    __nonzero__ = __bool__  # Python 2
+
+
     def __getstate__(self):
         return (self.directory, self.timeout, type(self.disk))
 

--- a/diskcache/fanout.py
+++ b/diskcache/fanout.py
@@ -487,6 +487,14 @@ class FanoutCache(object):
         return sum(len(shard) for shard in self._shards)
 
 
+    def __bool__(self):
+        # Always True, implemented to prevent fallback to __len__
+        return True
+
+
+    __nonzero__ = __bool__  # Python 2
+
+
     def reset(self, key, value=ENOVAL):
         """Reset `key` and `value` item from Settings table.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1493,6 +1493,10 @@ def test_lru_incr(cache):
     assert cache[0] == 0
 
 
+@setup_cache
+def test_cache_truthy(cache):
+    assert bool(cache) is True
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/test_fanout.py
+++ b/tests/test_fanout.py
@@ -712,6 +712,11 @@ def test_custom_filename_disk():
     shutil.rmtree('tmp', ignore_errors=True)
 
 
+@setup_cache
+def test_cache_truthy(cache):
+    assert bool(cache) is True
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
These always return True. Before these changes Python would fallback to __len__ which would be falsy if there were no cache entries.

The reason for this is that I'm trying to use DiskCache as a cache backend for CacheControl. But because an empty cache objects tests falsy it will never be used.