### PR TITLE
extend .gitignore with venv, some IDEs and eggs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,19 @@
 # Python byte-code
+__pycache__/
 *.py[co]
 
 # virutalenv directories
 /env*/
+/venv*/
+/.venv*/
+
+# Vim IDE
+*~
+*.swp
+*.swo
+
+ # IntelliJ IDEA
+.idea/
 
 # coverage files
 .coverage
@@ -12,5 +23,8 @@
 /build/
 /dist/
 /diskcache.egg-info/
+/eggs/
+/.eggs/
+/tmp/
 
 .DS_Store


### PR DESCRIPTION
PyCharm is a common used Python IDE that generates some files
that have nothing to do with the project.

Also added `venv/` and `.venv/` folders since some python virtual
environment tools create this folders instead of `env/`.