### PR TITLE
Possible example of a readonly cache.

### DIFF
--- a/aaa.py
+++ b/aaa.py
@@ -1,6 +1,6 @@
 import diskcache
 
-a = diskcache.Cache('/tmp/abcde', sqlite_read_only=True)
+a = diskcache.Cache('/tmp/abcde', read_only=True)
 
 o = [1, 2, 3, 4]
 a['qq'] = o

--- a/aaa.py
+++ b/aaa.py
@@ -1,0 +1,12 @@
+import diskcache
+
+a = diskcache.Cache('/tmp/abcde', sqlite_read_only=True)
+
+o = [1, 2, 3, 4]
+a['qq'] = o
+
+for k in a:
+    print(k)
+
+o = [1, 2, 3, 4]
+a['qqe'] = o

--- a/aaa.py
+++ b/aaa.py
@@ -1,6 +1,7 @@
 import diskcache
 
 a = diskcache.Cache('/tmp/abcde', sqlite_query_only=True)
+print(f'Query-only: ', a.sqlite_query_only)
 
 o = [1, 2, 3, 4]
 # a['qq'] = o
@@ -9,4 +10,5 @@ for k in a:
     print(k)
 
 o = [1, 2, 3, 4]
-# a['qqe'] = o
+a['qqe'] = o
+

--- a/aaa.py
+++ b/aaa.py
@@ -1,12 +1,12 @@
 import diskcache
 
-a = diskcache.Cache('/tmp/abcde', read_only=True)
+a = diskcache.Cache('/tmp/abcde', sqlite_query_only=True)
 
 o = [1, 2, 3, 4]
-a['qq'] = o
+# a['qq'] = o
 
 for k in a:
     print(k)
 
 o = [1, 2, 3, 4]
-a['qqe'] = o
+# a['qqe'] = o

--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -80,6 +80,8 @@ MODE_BINARY = 2
 MODE_TEXT = 3
 MODE_PICKLE = 4
 
+# settings starting with sqlite_ are used as PRAGMAs in sqlite
+# use with care
 DEFAULT_SETTINGS = {
     u'statistics': 0,  # False
     u'tag_index': 0,   # False

--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -442,6 +442,7 @@ class Cache(object):
                         ' and could not be created' % self._directory
                     )
 
+        # this must be processed now because it is used in Cache._con
         self.read_only = settings.get('read_only', False)
 
         sql = self._sql_retry
@@ -610,7 +611,7 @@ class Cache(object):
         if con is None:
             if self.read_only:
                 p = op.join(self._directory, DBNAME)
-                uri = f'file:{p}?mode=ro'
+                uri = 'file:%s?mode=ro' % p
                 con = self._local.con = sqlite3.connect(
                     uri,
                     uri=True,

--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -572,8 +572,6 @@ class Cache(object):
         # Close and re-open database connection with given timeout.
 
         self.close()
-        # PRAGMAs are not reapplied to the next connect
-        # which means transient PRAGMAs as query_only are out of sync with member variables
         self._timeout = timeout
         self._sql  # pylint: disable=pointless-statement
 
@@ -632,11 +630,10 @@ class Cache(object):
                     if key.startswith('sqlite_'):
                         self.reset(key, value, update=False)
 
-            # must be done *after* the settings update
-            # as the value of this pragma from settings is always 0
+            # the settings read fro the DB never contain query_only
+            # so we manually force it here, if it has been passed as a parameter
             if self.open_in_query_only:
-                read_only_pragma = 'PRAGMA query_only = 1'
-                con.execute(read_only_pragma)
+                self.reset('sqlite_query_only', 1, update=False)
 
         return con
 

--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -573,7 +573,7 @@ class Cache(object):
 
         self.close()
         # PRAGMAs are not reapplied to the next connect
-        # which means transient PRAGMAs as query_only are out of sync
+        # which means transient PRAGMAs as query_only are out of sync with member variables
         self._timeout = timeout
         self._sql  # pylint: disable=pointless-statement
 


### PR DESCRIPTION
This is a minimal example of a Read Only cache.

It could be made more explicit by checking the flag at the API boundary but I wanted to make it as small a change as possible.

The only issue is with the potential infinite loop which needs to be broken. I have not tried the entire API to ensure it does not hang.

I am not asking to commit as is, just to take it as a suggestion.