### PR TITLE
Query only support

### DIFF
--- a/diskcache/__init__.py
+++ b/diskcache/__init__.py
@@ -44,8 +44,8 @@ except Exception:  # pylint: disable=broad-except
     pass
 
 __title__ = 'diskcache'
-__version__ = '4.0.0'
-__build__ = 0x040000
+__version__ = '4.1.0'
+__build__ = 0x040100
 __author__ = 'Grant Jenks'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2016-2018 Grant Jenks'

--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -680,6 +680,8 @@ class Cache(object):
             # Settings table may not exist so catch and ignore the
             # OperationalError that may occur.
 
+            sqlite_query_only = self.sqlite_query_only
+
             try:
                 select = 'SELECT key, value FROM Settings'
                 settings = con.execute(select).fetchall()
@@ -690,13 +692,10 @@ class Cache(object):
                     if key.startswith('sqlite_'):
                         self.reset(key, value, update=False)
 
-            # The settings read from the database never contain
-            # sqlite_query_only. Manually force it here, if it has been passed
-            # as a parameter.
-
-            if self.sqlite_query_only:
-                # TODO: I don't think this'll work. The previous reset() will
-                # overwrite self.sqlite_query_only.
+            # The settings read from the database always contain sqlite_query_only=0.
+            # So the above loop will have overwritten self.sqlite_query_only
+            # Here we restore it to the value we had before
+            if sqlite_query_only:
                 self.reset('sqlite_query_only', 1, update=False)
 
         return con

--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -2081,9 +2081,10 @@ class Cache(object):
         :raises Timeout: if database timeout occurs
 
         """
-        sql = self._sql
-        sql('CREATE INDEX IF NOT EXISTS Cache_tag_rowid ON Cache(tag, rowid)')
-        self.reset('tag_index', 1)
+        if self.tag_index == 0:
+            sql = self._sql
+            sql('CREATE INDEX IF NOT EXISTS Cache_tag_rowid ON Cache(tag, rowid)')
+            self.reset('tag_index', 1)
 
 
     def drop_tag_index(self):
@@ -2092,9 +2093,10 @@ class Cache(object):
         :raises Timeout: if database timeout occurs
 
         """
-        sql = self._sql
-        sql('DROP INDEX IF EXISTS Cache_tag_rowid')
-        self.reset('tag_index', 0)
+        if self.tag_index == 1:
+            sql = self._sql
+            sql('DROP INDEX IF EXISTS Cache_tag_rowid')
+            self.reset('tag_index', 0)
 
 
     def evict(self, tag, retry=False):

--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -105,7 +105,7 @@ METADATA = {
 }
 
 # TODO: these cannot be verified for a read_only database
-UNVERIFIABLE_FIELDS = ['sqlite_query_only', 'count']
+UNVERIFIABLE_SETTINGS = ['sqlite_query_only']
 
 EVICTION_POLICY = {
     'none': {
@@ -544,7 +544,7 @@ class Cache(object):
                 query = 'SELECT value FROM Settings WHERE key = ?'
                 db_value = sql(query, (key,)).fetchall()
                 assert len(db_value) == 1
-                if key not in UNVERIFIABLE_FIELDS:
+                if key not in UNVERIFIABLE_SETTINGS:
                     assert value == db_value[0][0]
             else:
                 query = 'INSERT OR REPLACE INTO Settings VALUES (?, ?)'
@@ -552,13 +552,7 @@ class Cache(object):
             self.reset(key, value, update=(not self.sqlite_query_only))
 
         for key, value in METADATA.items():
-            if self.sqlite_query_only:
-                query = 'SELECT value FROM Settings WHERE key = ?'
-                db_value = sql(query, (key,)).fetchall()
-                assert len(db_value) == 1
-                if key not in UNVERIFIABLE_FIELDS:
-                    assert value == db_value[0][0]
-            else:
+            if not self.sqlite_query_only:
                 query = 'INSERT OR IGNORE INTO Settings VALUES (?, ?)'
                 sql(query, (key, value))
             self.reset(key, update=(not self.sqlite_query_only))

--- a/diskcache/persistent.py
+++ b/diskcache/persistent.py
@@ -442,7 +442,7 @@ class Deque(Sequence):
 
 
     def peekleft(self):
-        """Peek at value at back of deque.
+        """Peek at value at front of deque.
 
         Faster than indexing deque at 0.
 


### PR DESCRIPTION
1) fix the assertion for setting comparison (dbvalue is a list of tuples)
2) skip 2 fields that cannot be compared for a ro cache (not sure about "count")
3) tag_index: make it a noop if the setting is unchanged

With this the ro cache runs.

Tests are still missing.
