### PR TITLE
Use a proper temporary directory for testing

### DIFF
--- a/tests/test_deque.py
+++ b/tests/test_deque.py
@@ -5,6 +5,7 @@ import mock
 import pickle
 import pytest
 import shutil
+import tempfile
 
 import diskcache as dc
 from diskcache.core import ENOVAL
@@ -25,28 +26,28 @@ def deque():
 
 
 def test_init():
-    directory = '/tmp/diskcache/deque'
-    sequence = list('abcde')
-    deque = dc.Deque(sequence, None)
+    with tempfile.TemporaryDirectory() as directory:
+        sequence = list('abcde')
+        deque = dc.Deque(sequence, None)
 
-    assert deque == sequence
+        assert deque == sequence
 
-    rmdir(deque.directory)
-    del deque
+        rmdir(deque.directory)
+        del deque
 
-    rmdir(directory)
-    deque = dc.Deque(sequence, directory)
+        rmdir(directory)
+        deque = dc.Deque(sequence, directory)
 
-    assert deque.directory == directory
-    assert deque == sequence
+        assert deque.directory == directory
+        assert deque == sequence
 
-    other = dc.Deque(directory=directory)
+        other = dc.Deque(directory=directory)
 
-    assert other == deque
+        assert other == deque
 
-    del deque
-    del other
-    rmdir(directory)
+        del deque
+        del other
+        rmdir(directory)
 
 
 def test_getsetdel(deque):
@@ -155,9 +156,9 @@ def test_indexerror(deque):
 
 
 def test_repr():
-    directory = '/tmp/diskcache/deque'
-    deque = dc.Deque(directory=directory)
-    assert repr(deque) == 'Deque(directory=%r)' % directory
+    with tempfile.TemporaryDirectory() as directory:
+        deque = dc.Deque(directory=directory)
+        assert repr(deque) == 'Deque(directory=%r)' % directory
 
 
 def test_count(deque):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -6,6 +6,7 @@ import pickle
 import pytest
 import shutil
 import sys
+import tempfile
 
 import diskcache as dc
 
@@ -25,37 +26,37 @@ def index():
 
 
 def test_init():
-    directory = '/tmp/diskcache/index'
-    mapping = {'a': 5, 'b': 4, 'c': 3, 'd': 2, 'e': 1}
-    index = dc.Index(None, mapping)
+    with tempfile.TemporaryDirectory() as directory:
+        mapping = {'a': 5, 'b': 4, 'c': 3, 'd': 2, 'e': 1}
+        index = dc.Index(None, mapping)
 
-    assert index == mapping
+        assert index == mapping
 
-    rmdir(index.directory)
-    del index
+        rmdir(index.directory)
+        del index
 
-    rmdir(directory)
-    index = dc.Index(directory, mapping)
+        rmdir(directory)
+        index = dc.Index(directory, mapping)
 
-    assert index.directory == directory
-    assert index == mapping
+        assert index.directory == directory
+        assert index == mapping
 
-    other = dc.Index(directory)
+        other = dc.Index(directory)
 
-    assert other == index
+        assert other == index
 
-    del index
-    del other
-    rmdir(directory)
-    index = dc.Index(directory, mapping.items())
+        del index
+        del other
+        rmdir(directory)
+        index = dc.Index(directory, mapping.items())
 
-    assert index == mapping
+        assert index == mapping
 
-    del index
-    rmdir(directory)
-    index = dc.Index(directory, a=5, b=4, c=3, d=2, e=1)
+        del index
+        rmdir(directory)
+        index = dc.Index(directory, a=5, b=4, c=3, d=2, e=1)
 
-    assert index == mapping
+        assert index == mapping
 
 
 def test_getsetdel(index):


### PR DESCRIPTION
Use a tempfile.TemporaryDirectory() instead of hardcoding
/tmp/diskcache.  Besides being insecure (you are removing a directory
that might have been incidentally used by user!), it fails when multiple
users were running tests on the same machine (as the later user is
unable to remove the directory created by the earlier user).