### PR TITLE
tests: Use unittest.mock over external mock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django==1.11.*
 django_redis
 doc8
 gj
-mock
+mock;python_version<"3.3"
 nose
 pylibmc
 pylint

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,6 @@ import errno
 import functools as ft
 import hashlib
 import io
-import mock
 import os
 import os.path as op
 import pytest
@@ -26,6 +25,11 @@ try:
     import cPickle as pickle
 except:
     import pickle
+
+try:
+    from unittest import mock
+except:
+    import mock
 
 import diskcache
 import diskcache as dc

--- a/tests/test_deque.py
+++ b/tests/test_deque.py
@@ -1,10 +1,14 @@
 "Test diskcache.persistent.Deque."
 
 import functools as ft
-import mock
 import pickle
 import pytest
 import shutil
+
+try:
+    from unittest import mock
+except:
+    import mock
 
 import diskcache as dc
 from diskcache.core import ENOVAL

--- a/tests/test_fanout.py
+++ b/tests/test_fanout.py
@@ -7,7 +7,6 @@ import errno
 import functools as ft
 import hashlib
 import io
-import mock
 import os
 import os.path as op
 import pytest
@@ -20,6 +19,11 @@ import tempfile
 import threading
 import time
 import warnings
+
+try:
+    from unittest import mock
+except:
+    import mock
 
 try:
     import cPickle as pickle

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,11 +1,15 @@
 "Test diskcache.persistent.Index."
 
 import functools as ft
-import mock
 import pickle
 import pytest
 import shutil
 import sys
+
+try:
+    from unittest import mock
+except:
+    import mock
 
 import diskcache as dc
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,11 +1,15 @@
 "Test diskcache.recipes."
 
 import diskcache as dc
-import mock
 import pytest
 import shutil
 import threading
 import time
+
+try:
+    from unittest import mock
+except:
+    import mock
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters=True
 [testenv]
 deps=
     django==1.11.*
-    mock
+    mock;python_version<"3.3"
     pytest==4.6.*
     pytest-django
     pytest-xdist


### PR DESCRIPTION
Mocking support is built-in since Python 3.3.  Use it over external
mock when available.  This helps distributions that are phasing Python 2
out and would like to remove mock package as part of that.