### PR TITLE
Fix compatibility with newer versions of django

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coverage
-django==1.11.*
+django
 django_redis
 doc8
 gj

--- a/tests/test_djangocache.py
+++ b/tests/test_djangocache.py
@@ -18,6 +18,11 @@ import time
 import unittest
 import warnings
 
+try:
+    from unittest import mock
+except:
+    import mock
+
 from django.conf import settings
 from django.core import management, signals
 from django.core.cache import (
@@ -37,15 +42,14 @@ from django.template.context_processors import csrf
 from django.template.response import TemplateResponse
 from django.test import (
     RequestFactory, SimpleTestCase, TestCase, TransactionTestCase,
-    ignore_warnings, mock, override_settings,
+    override_settings,
 )
 from django.test.signals import setting_changed
-from django.utils import six, timezone, translation
+from django.utils import timezone, translation
 from django.utils.cache import (
     get_cache_key, learn_cache_key, patch_cache_control,
     patch_response_headers, patch_vary_headers,
 )
-from django.utils.deprecation import RemovedInDjango21Warning
 from django.utils.encoding import force_text
 from django.views.decorators.cache import cache_page
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters=True
 
 [testenv]
 deps=
-    django==1.11.*
+    django
     mock
     pytest==4.6.*
     pytest-django


### PR DESCRIPTION
Remove unused imports and switch to built-in mock module (akin to #24).
Fixes #136.