### PR TITLE
cache.get returns default value when pickle reader encounters EOFError 

### DIFF
--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -271,7 +271,14 @@ class Disk(object):
         elif mode == MODE_PICKLE:
             if value is None:
                 with open(op.join(self._directory, filename), 'rb') as reader:
-                    return pickle.load(reader)
+                    try:
+                        return pickle.load(reader)
+                    except EOFError as error:
+                        raise IOError(
+                            errno.ENOENT,
+                            'File cannot be read by pickle',
+                            op.join(self._directory, filename)
+                        ) from error
             else:
                 return pickle.load(io.BytesIO(value))
 


### PR DESCRIPTION
, which behaves in the same way as FileNotFoundError.

EOFError happened when a blank file is read by pickle reader.  I don't know specifically what is going on why blank file is there, instead of large file. Although, EOFError is going to throw permanently.

FYO.  The `io.IOBase` returns empty string instead. https://docs.python.org/3/library/exceptions.html#EOFError
> (N.B.: the io.IOBase.read() and io.IOBase.readline() methods return an empty string when they hit EOF.

Addition: This PR is just to take it as a suggestion, thus it is closable.