### PR TITLE
Memoizing cache decorator with cache lease.

### DIFF
--- a/diskcache/recipes.py
+++ b/diskcache/recipes.py
@@ -539,10 +539,9 @@ def memoize_lease(cache, expire, lease, name=None, typed=False, tag=None):
         def wrapper(*args, **kwargs):
             "Wrapper for callable to cache arguments and return values."
             key = wrapper.__cache_key__(*args, **kwargs)
-            trio, expire_time = cache.get(
+            trio = cache.get(
                 key,
                 default=ENOVAL,
-                expire_time=True,
                 retry=True,
             )
 


### PR DESCRIPTION
def memoize_lease(cache, expire, lease, name=None, typed=False, tag=None):

The `expire` argument is a "hard deadline" for evicting cache entries. Set
`expire` to `None` to avoid evictions due to expiration.

The `lease` represents a "soft deadline" for the memoized cache entry. Once
the lease time has passed, cache entries will be updated asynchronously
using a background thread. At most one background thread will be started
for each cache entry. While the background thread is executing, memoized
cache entries will continue to be treated as "cache hits" until expiration.

If name is set to None (default), the callable name will be determined
automatically.

If typed is set to True, function arguments of different types will be
cached separately. For example, f(3) and f(3.0) will be treated as distinct
calls with distinct results.

The original underlying function is accessible through the `__wrapped__`
attribute. This is useful for introspection, for bypassing the cache, or
for rewrapping the function with a different cache.

>>> from diskcache import Cache
>>> cache = Cache()
>>> @memoize_lease(cache, expire=10, lease=1)
... def fib(number):
...     if number == 0:
...         return 0
...     elif number == 1:
...         return 1
...     else:
...         return fib(number - 1) + fib(number - 2)
>>> print(fib(100))
354224848179261915075

An additional `__cache_key__` attribute can be used to generate the cache
key used for the given arguments.

>>> key = fib.__cache_key__(100)
>>> del cache[key]

Remember to call memoize when decorating a callable. If you forget, then a
TypeError will occur.

:param cache: cache to store callable arguments and return values
:param float expire: seconds until arguments expire
:param float lease: minimum seconds after last execution
                    we want to update the cache value
:param str name: name given for callable (default None, automatic)
:param bool typed: cache different types separately (default False)
:param str tag: text to associate with arguments (default None)
:return: callable decorator