### PR TITLE
Add possibility to ignore args/kwargs in memoize decorator

### DIFF
--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -390,7 +390,7 @@ class EmptyDirWarning(UserWarning):
     "Warning used by Cache.check for empty directories."
 
 
-def args_to_key(base, args, kwargs, typed):
+def args_to_key(base, args, kwargs, typed, ignored_args = None, ignored_kwargs = None):
     """Create cache key out of function arguments.
 
     :param tuple base: base of key
@@ -400,9 +400,13 @@ def args_to_key(base, args, kwargs, typed):
     :return: cache key tuple
 
     """
+    if args is not None and ignored_args is not None:
+        args = tuple(arg for i, arg in enumerate(args) if not i in ignored_args)
     key = base + args
 
     if kwargs:
+        if ignored_kwargs is not None:
+            kwargs = {k:v for (k, v) in kwargs.items() if not k in ignored_kwargs}
         key += (ENOVAL,)
         sorted_items = sorted(kwargs.items())
 
@@ -1809,7 +1813,7 @@ class Cache:
         else:
             return key, value
 
-    def memoize(self, name=None, typed=False, expire=None, tag=None):
+    def memoize(self, name=None, typed=False, expire=None, tag=None, ignored_args=None, ignored_kwargs=None):
         """Memoizing cache decorator.
 
         Decorator to wrap callable with memoizing function using cache.
@@ -1894,7 +1898,7 @@ class Cache:
 
             def __cache_key__(*args, **kwargs):
                 "Make key for cache given function arguments."
-                return args_to_key(base, args, kwargs, typed)
+                return args_to_key(base, args, kwargs, typed, ignored_args, ignored_kwargs)
 
             wrapper.__cache_key__ = __cache_key__
             return wrapper

--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -390,23 +390,24 @@ class EmptyDirWarning(UserWarning):
     "Warning used by Cache.check for empty directories."
 
 
-def args_to_key(base, args, kwargs, typed, ignored_args = None, ignored_kwargs = None):
+def args_to_key(base, args, kwargs, typed, ignored_arguments = None):
     """Create cache key out of function arguments.
 
     :param tuple base: base of key
     :param tuple args: function arguments
     :param dict kwargs: function keyword arguments
     :param bool typed: include types in cache key
+    :param ignored_arguments: ignore these arguments while determining caching key, 'int' for positional arguments in 'args', 'str' for named arguments in 'kwargs' (default: None)
     :return: cache key tuple
 
     """
-    if args is not None and ignored_args is not None:
-        args = tuple(arg for i, arg in enumerate(args) if not i in ignored_args)
+    if args is not None and ignored_arguments is not None:
+        args = tuple(arg for i, arg in enumerate(args) if not i in ignored_arguments)
     key = base + args
 
     if kwargs:
-        if ignored_kwargs is not None:
-            kwargs = {k:v for (k, v) in kwargs.items() if not k in ignored_kwargs}
+        if ignored_arguments is not None:
+            kwargs = {k:v for (k, v) in kwargs.items() if not k in ignored_arguments}
         key += (ENOVAL,)
         sorted_items = sorted(kwargs.items())
 
@@ -1813,7 +1814,7 @@ class Cache:
         else:
             return key, value
 
-    def memoize(self, name=None, typed=False, expire=None, tag=None, ignored_args=None, ignored_kwargs=None):
+    def memoize(self, name=None, typed=False, expire=None, tag=None, ignored_arguments=None):
         """Memoizing cache decorator.
 
         Decorator to wrap callable with memoizing function using cache.
@@ -1872,6 +1873,7 @@ class Cache:
         :param float expire: seconds until arguments expire
             (default None, no expiry)
         :param str tag: text to associate with arguments (default None)
+        :param ignored_arguments: ignore these arguments while determining caching key, 'int' for positional arguments in 'args', 'str' for named arguments in 'kwargs' (default: None)
         :return: callable decorator
 
         """
@@ -1898,7 +1900,7 @@ class Cache:
 
             def __cache_key__(*args, **kwargs):
                 "Make key for cache given function arguments."
-                return args_to_key(base, args, kwargs, typed, ignored_args, ignored_kwargs)
+                return args_to_key(base, args, kwargs, typed, ignored_arguments)
 
             wrapper.__cache_key__ = __cache_key__
             return wrapper

--- a/diskcache/djangocache.py
+++ b/diskcache/djangocache.py
@@ -373,6 +373,7 @@ class DjangoCache(BaseCache):
         version=None,
         typed=False,
         tag=None,
+        ignored_arguments=None
     ):
         """Memoizing cache decorator.
 
@@ -407,6 +408,7 @@ class DjangoCache(BaseCache):
         :param int version: key version number (default None, cache parameter)
         :param bool typed: cache different types separately (default False)
         :param str tag: text to associate with arguments (default None)
+        :param ignored_arguments: ignore these arguments while determining caching key, 'int' for positional arguments in 'args', 'str' for named arguments in 'kwargs' (default: None)
         :return: callable decorator
 
         """
@@ -445,7 +447,7 @@ class DjangoCache(BaseCache):
 
             def __cache_key__(*args, **kwargs):
                 "Make key for cache given function arguments."
-                return args_to_key(base, args, kwargs, typed)
+                return args_to_key(base, args, kwargs, typed, ignored_arguments)
 
             wrapper.__cache_key__ = __cache_key__
             return wrapper

--- a/diskcache/recipes.py
+++ b/diskcache/recipes.py
@@ -338,7 +338,7 @@ def barrier(cache, lock_factory, name=None, expire=None, tag=None):
     return decorator
 
 
-def memoize_stampede(cache, expire, name=None, typed=False, tag=None, beta=1):
+def memoize_stampede(cache, expire, name=None, typed=False, tag=None, beta=1, ignored_arguments=None):
     """Memoizing cache decorator with cache stampede protection.
 
     Cache stampedes are a type of system overload that can occur when parallel
@@ -391,6 +391,7 @@ def memoize_stampede(cache, expire, name=None, typed=False, tag=None, beta=1):
     :param str name: name given for callable (default None, automatic)
     :param bool typed: cache different types separately (default False)
     :param str tag: text to associate with arguments (default None)
+    :param ignored_arguments: ignore these arguments while determining caching key, 'int' for positional arguments in 'args', 'str' for named arguments in 'kwargs' (default: None)
     :return: callable decorator
 
     """
@@ -460,7 +461,7 @@ def memoize_stampede(cache, expire, name=None, typed=False, tag=None, beta=1):
 
         def __cache_key__(*args, **kwargs):
             "Make key for cache given function arguments."
-            return args_to_key(base, args, kwargs, typed)
+            return args_to_key(base, args, kwargs, typed, ignored_arguments)
 
         wrapper.__cache_key__ = __cache_key__
         return wrapper

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1466,7 +1466,7 @@ def test_memoize_ignored_args(cache):
     def fn_cached(arg1, arg2, arg3, arg4):
         return True
 
-    @cache.memoize(ignored_args = [0], ignored_kwargs = ['arg4'])
+    @cache.memoize(ignored_arguments = [0, 'arg4'])
     def fn_cached_with_ignore(arg1, arg2, arg3, arg4):
         return True
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1459,3 +1459,29 @@ def test_memoize(cache):
 
     assert hits2 == (hits1 + count)
     assert misses2 == misses1
+
+def test_memoize_ignored_args(cache):
+
+    @cache.memoize()
+    def fn_cached(arg1, arg2, arg3, arg4):
+        return True
+
+    @cache.memoize(ignored_args = [0], ignored_kwargs = ['arg4'])
+    def fn_cached_with_ignore(arg1, arg2, arg3, arg4):
+        return True
+
+     
+    cache.stats(enable=True)    
+    fn_cached(1, 2, arg3 = 3, arg4 = 4)
+    fn_cached(1, 2, arg3 = 3, arg4 = 4)
+    fn_cached(2, 2, arg3 = 3, arg4 = 5)
+    hits1, misses1 = cache.stats(reset = True)
+    assert hits1 == 1
+    assert misses1 == 2
+    
+    fn_cached_with_ignore(1, 2, arg3 = 3, arg4 = 4)
+    fn_cached_with_ignore(1, 2, arg3 = 3, arg4 = 4)
+    fn_cached_with_ignore(2, 2, arg3 = 3, arg4 = 5)
+    hits1, misses1 = cache.stats(reset = True)
+    assert hits1 == 2
+    assert misses1 == 1


### PR DESCRIPTION
Example call:
   @cache.memoize(ignored_args = [0], ignored_kwargs = ['arg4'])