### PR TITLE
Implement PEP 562 for Python >= 3.7

### DIFF
--- a/diskcache/__init__.py
+++ b/diskcache/__init__.py
@@ -5,60 +5,104 @@ DiskCache API Reference
 The :doc:`tutorial` provides a helpful walkthrough of most methods.
 """
 
-from .core import (
-    DEFAULT_SETTINGS,
-    ENOVAL,
-    EVICTION_POLICY,
-    UNKNOWN,
-    Cache,
-    Disk,
-    EmptyDirWarning,
-    JSONDisk,
-    Timeout,
-    UnknownFileWarning,
-)
-from .fanout import FanoutCache
-from .persistent import Deque, Index
-from .recipes import (
-    Averager,
-    BoundedSemaphore,
-    Lock,
-    RLock,
-    barrier,
-    memoize_stampede,
-    throttle,
-)
+import importlib
+import sys
 
-__all__ = [
-    'Averager',
-    'BoundedSemaphore',
-    'Cache',
-    'DEFAULT_SETTINGS',
-    'Deque',
-    'Disk',
-    'ENOVAL',
-    'EVICTION_POLICY',
-    'EmptyDirWarning',
-    'FanoutCache',
-    'Index',
-    'JSONDisk',
-    'Lock',
-    'RLock',
-    'Timeout',
-    'UNKNOWN',
-    'UnknownFileWarning',
-    'barrier',
-    'memoize_stampede',
-    'throttle',
-]
+_objects_modules = {
+    'DEFAULT_SETTINGS': 'core',
+    'ENOVAL': 'core',
+    'EVICTION_POLICY': 'core',
+    'UNKNOWN': 'core',
+    'Cache': 'core',
+    'Disk': 'core',
+    'EmptyDirWarning': 'core',
+    'JSONDisk': 'core',
+    'Timeout': 'core',
+    'UnknownFileWarning': 'core',
+    'FanoutCache': 'fanout',
+    'Deque': 'persistent',
+    'Index': 'persistent',
+    'Averager': 'recipes',
+    'BoundedSemaphore': 'recipes',
+    'Lock': 'recipes',
+    'RLock': 'recipes',
+    'barrier': 'recipes',
+    'memoize_stampede': 'recipes',
+    'throttle': 'recipes',
+    'DjangoCache': 'djangocache',
+}
 
-try:
-    from .djangocache import DjangoCache  # noqa
+# Implement PEP 562 on Python > 3.6 to avoid uneeded imports
+if sys.version_info < (3, 7):
+    del _objects_modules['DjangoCache']
+    __all__ = list(_objects_modules.keys())
 
-    __all__.append('DjangoCache')
-except Exception:  # pylint: disable=broad-except  # pragma: no cover
-    # Django not installed or not setup so ignore.
-    pass
+    _loaded_modules = {}
+
+    for _object_name, _modname in _objects_modules.items():
+        if _modname not in _loaded_modules:
+            _loaded_modules[_modname] = importlib.import_module(
+                f'diskcache.{_modname}'
+            )
+        globals()[_object_name] = getattr(
+            _loaded_modules[_modname],
+            _object_name,
+        )
+
+    try:
+        from .djangocache import DjangoCache  # noqa
+
+        __all__.append('DjangoCache')
+    except ImportError as err:  # pragma: no cover
+        if err.name != "django":
+            raise
+        # Django not installed or not setup so ignore.
+else:
+
+    def _all__():
+        __all__ = list(_objects_modules.keys())
+        try:
+            from .djangocache import DjangoCache  # noqa
+
+            __all__.append('DjangoCache')
+        except Exception:  # pylint: disable=broad-except  # pragma: no cover
+            # Django not installed or not setup so ignore.
+            pass
+        return __all__
+
+    def __dir__():
+        __all__ = _all__()
+        del globals()['_all__']
+        return __all__ + list(globals())
+
+    def __getattr__(name):
+        if name == '__all__':
+            return _all__()
+        elif name.startswith('__'):
+            # Internal dunder name like __path__
+            return globals()[name]
+
+        try:
+            modname = _objects_modules[name]
+        except KeyError:
+            raise ImportError(
+                f"cannot import name '{name}' from diskcache",
+                name=name,
+            ) from None
+        else:
+            try:
+                _module = importlib.import_module(f'diskcache.{modname}')
+            except ImportError as err:
+                # Manage django import error of DjangoCache in the same way
+                # as non existing in __all__
+                if name == 'DjangoCache' and err.name == "django":
+                    raise ImportError(
+                        f"cannot import name '{name}' from diskcache",
+                        name=name,
+                    ) from None
+                raise
+            return getattr(_module, name)
+
 
 __title__ = 'diskcache'
 __version__ = '5.4.0'


### PR DESCRIPTION
Currently when importing whatever object from diskcache, if `django` is installed it is imported. You can see it in the next image generated by [pyinstrument](https://github.com/joerick/pyinstrument):

![image](https://user-images.githubusercontent.com/23049315/208264054-1991e400-0aba-463c-a218-4dc4350f173d.png)

To avoid that, this PR implements [PEP 562](https://peps.python.org/pep-0562/) on the *__init__.py* file for Python 3.7 onwards. After it, when importing whatever object, like with `from diskcache import Cache` for example, django is not imported:

![image](https://user-images.githubusercontent.com/23049315/208264064-266eaa9e-359b-4bcb-acc6-8fd7713f6438.png)

According to my benchmarks, this avoids ~100ms on all imports except `DjangoCache`. Especially useful in CLI programs that don't need django and should start as fast as possible.