### PR TITLE
Bug fix: Fix peek when value is so large that a file is used

### DIFF
--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -1703,9 +1703,6 @@ class Cache:
             except IOError:
                 # Key was deleted before we could retrieve result.
                 continue
-            finally:
-                if name is not None:
-                    self._disk.remove(name)
             break
 
         if expire_time and tag:

--- a/tests/test_deque.py
+++ b/tests/test_deque.py
@@ -302,3 +302,13 @@ def test_rotate_indexerror_negative(deque):
 
     with mock.patch.object(deque, '_cache', cache):
         deque.rotate(-1)
+
+
+def test_peek(deque):
+    value = b'x' * 100_000
+    deque.append(value)
+    assert len(deque) == 1
+    assert deque.peek() == value
+    assert len(deque) == 1
+    assert deque.peek() == value
+    assert len(deque) == 1


### PR DESCRIPTION
Bug fix: Fix peek when value is so large that a file is used.

Error caused by copy/paste from pull().