### PR TITLE
Change `Cache_expire_time` to a partial index because we don't need to query rows efficiently `where expire_time IS NULL`

### DIFF
--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -531,7 +531,7 @@ class Cache:
 
         sql(
             'CREATE INDEX IF NOT EXISTS Cache_expire_time ON'
-            ' Cache (expire_time)'
+            ' Cache (expire_time) WHERE expire_time IS NOT NULL'
         )
 
         query = EVICTION_POLICY[self.eviction_policy]['init']


### PR DESCRIPTION
Read https://www.sqlite.org/partialindex.html for an explanation.

The queries are already using `where expire_time IS NULL and ..`, so didn't see a need to change there.