### PR TITLE
Support sqlite builds with DQS=off

### DIFF
--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -542,39 +542,39 @@ class Cache:
         # Use triggers to keep Metadata updated.
 
         sql(
-            'CREATE TRIGGER IF NOT EXISTS Settings_count_insert'
-            ' AFTER INSERT ON Cache FOR EACH ROW BEGIN'
-            ' UPDATE Settings SET value = value + 1'
-            ' WHERE key = "count"; END'
+            "CREATE TRIGGER IF NOT EXISTS Settings_count_insert"
+            " AFTER INSERT ON Cache FOR EACH ROW BEGIN"
+            " UPDATE Settings SET value = value + 1"
+            " WHERE key = 'count'; END"
         )
 
         sql(
-            'CREATE TRIGGER IF NOT EXISTS Settings_count_delete'
-            ' AFTER DELETE ON Cache FOR EACH ROW BEGIN'
-            ' UPDATE Settings SET value = value - 1'
-            ' WHERE key = "count"; END'
+            "CREATE TRIGGER IF NOT EXISTS Settings_count_delete"
+            " AFTER DELETE ON Cache FOR EACH ROW BEGIN"
+            " UPDATE Settings SET value = value - 1"
+            " WHERE key = 'count'; END"
         )
 
         sql(
-            'CREATE TRIGGER IF NOT EXISTS Settings_size_insert'
-            ' AFTER INSERT ON Cache FOR EACH ROW BEGIN'
-            ' UPDATE Settings SET value = value + NEW.size'
-            ' WHERE key = "size"; END'
+            "CREATE TRIGGER IF NOT EXISTS Settings_size_insert"
+            " AFTER INSERT ON Cache FOR EACH ROW BEGIN"
+            " UPDATE Settings SET value = value + NEW.size"
+            " WHERE key = 'size'; END"
         )
 
         sql(
-            'CREATE TRIGGER IF NOT EXISTS Settings_size_update'
-            ' AFTER UPDATE ON Cache FOR EACH ROW BEGIN'
-            ' UPDATE Settings'
-            ' SET value = value + NEW.size - OLD.size'
-            ' WHERE key = "size"; END'
+            "CREATE TRIGGER IF NOT EXISTS Settings_size_update"
+            " AFTER UPDATE ON Cache FOR EACH ROW BEGIN"
+            " UPDATE Settings"
+            " SET value = value + NEW.size - OLD.size"
+            " WHERE key = 'size'; END"
         )
 
         sql(
-            'CREATE TRIGGER IF NOT EXISTS Settings_size_delete'
-            ' AFTER DELETE ON Cache FOR EACH ROW BEGIN'
-            ' UPDATE Settings SET value = value - OLD.size'
-            ' WHERE key = "size"; END'
+            "CREATE TRIGGER IF NOT EXISTS Settings_size_delete"
+            " AFTER DELETE ON Cache FOR EACH ROW BEGIN"
+            " UPDATE Settings SET value = value - OLD.size"
+            " WHERE key = 'size'; END"
         )
 
         # Create tag index if requested.
@@ -1177,10 +1177,10 @@ class Cache:
 
         else:  # Slow path, transaction required.
             cache_hit = (
-                'UPDATE Settings SET value = value + 1 WHERE key = "hits"'
+                "UPDATE Settings SET value = value + 1 WHERE key = 'hits'"
             )
             cache_miss = (
-                'UPDATE Settings SET value = value + 1 WHERE key = "misses"'
+                "UPDATE Settings SET value = value + 1 WHERE key = 'misses'"
             )
 
             with self._transact(retry) as (sql, _):


### PR DESCRIPTION
If sqlite3 is built with double-quoted string literals disabled (which is recommended, see https://www.sqlite.org/compile.html#dqs), diskcache starts failing with the following crypting error:

```
no such column: "size"
```

This is because the syntax `WHERE key = "size"` in standard SQL refers to a column named "size", not a string literal. Parsing this as a string literal is a conditional sqlite extension.

This patch makes the code more robust by avoiding this optional sqlite feature.