### PR TITLE
Make memoized `__cache_key__` invertible

### DIFF
--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -402,8 +402,7 @@ def args_to_key(base, args, kwargs, typed, ignore):
         kwargs = {key: val for key, val in kwargs.items() if key not in ignore}
         sorted_items = sorted(kwargs.items())
 
-        for item in sorted_items:
-            key += item
+        key += tuple(sorted_items)
 
     if typed:
         key += tuple(type(arg) for arg in args)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1405,3 +1405,21 @@ def test_memoize_iter(cache):
     assert len(cache) == 3
     for key in cache:
         assert cache[key] == 6
+
+
+def test_memoize_args_to_key_invertible(cache):
+    @cache.memoize()
+    def test(*args, **kwargs):
+        return (args, kwargs)
+
+    cache.clear()
+    assert test()
+    assert test(0)
+    assert test(a=0)
+    assert test(0, 1, 2, a=0, b=1, c=2)
+    assert test(None, "fake kwarg start", None)
+    assert test(None, "fake kwarg start", None, a=0)
+    assert test(bool, bytes, float, int, str)
+    for key in cache:
+        assert dc.key_to_args(key) == cache[key]
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1418,8 +1418,8 @@ def test_memoize_args_to_key_invertible(cache, typed):
     assert test(0)
     assert test(a=0)
     assert test(0, 1, 2, a=0, b=1, c=2)
-    assert test(None, 'fake kwarg start', None)
-    assert test(None, 'fake kwarg start', None, a=0)
+    assert test(None, 'fake kwarg start')
+    assert test(None, 'fake kwarg start', a=0)
     assert test(bool, bytes, float, int, str)
     for key in cache:
         args, kwargs = dc.core.key_to_args(key[1:])


### PR DESCRIPTION
Changes the `args_to_key` construction so that it both produces unique keys for its different arguments and implements its inverse `key_to_args`. Adds test to check the these as inverses.

See also https://github.com/grantjenks/python-diskcache/issues/313