### PR TITLE
Add link to API reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -375,6 +375,7 @@ Reference
 ---------
 
 * `DiskCache Documentation`_
+* `DiskCache API Reference`_
 * `DiskCache at PyPI`_
 * `DiskCache at GitHub`_
 * `DiskCache Issue Tracker`_


### PR DESCRIPTION
I found the API reference weirdly hard to find, since it's not on the Table of Contents in https://grantjenks.com/docs/diskcache/