### PR TITLE
Remove `python setup.py test`

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -76,10 +76,7 @@ Testing uses `tox <https://pypi.python.org/pypi/tox>`_. If you don't want to
 install all the development requirements, then, after downloading, you can
 simply run::
 
-    $ python setup.py test
-
-The test argument to setup.py will download a minimal testing infrastructure
-and run the tests.
+    $ tox
 
 ::
 

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,6 @@
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
 
 import diskcache
-
-
-class Tox(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import tox
-
-        errno = tox.cmdline(self.test_args)
-        exit(errno)
 
 
 with open('README.rst', encoding='utf-8') as reader:
@@ -36,8 +22,6 @@ setup(
     },
     license='Apache 2.0',
     packages=['diskcache'],
-    tests_require=['tox'],
-    cmdclass={'test': Tox},
     python_requires='>=3',
     install_requires=[],
     classifiers=(


### PR DESCRIPTION
For compatibility with setuptools>=72 (which removes the test command altogether)

See https://github.com/pypa/setuptools/issues/931