### PR TITLE
 Clarify optional None parameters in docstrings

### DIFF
--- a/diskcache/core.py
+++ b/diskcache/core.py
@@ -420,7 +420,7 @@ class Cache:
     def __init__(self, directory=None, timeout=60, disk=Disk, **settings):
         """Initialize cache instance.
 
-        :param str directory: cache directory
+        :param str or None directory: cache directory
         :param float timeout: SQLite connection timeout
         :param disk: Disk type or subclass for serialization
         :param settings: any of DEFAULT_SETTINGS
@@ -757,10 +757,10 @@ class Cache:
 
         :param key: key for item
         :param value: value for item
-        :param float expire: seconds until item expires
+        :param float or None expire: seconds until item expires
             (default None, no expiry)
         :param bool read: read value as bytes from file (default False)
-        :param str tag: text to associate with key (default None)
+        :param str or None tag: text to associate with key (default None)
         :param bool retry: retry if database timeout occurs (default False)
         :return: True if item was set
         :raises Timeout: if database timeout occurs
@@ -931,7 +931,7 @@ class Cache:
         `False` (default).
 
         :param key: key for item
-        :param float expire: seconds until item expires
+        :param float or None expire: seconds until item expires
             (default None, no expiry)
         :param bool retry: retry if database timeout occurs (default False)
         :return: True if key was touched
@@ -977,10 +977,10 @@ class Cache:
 
         :param key: key for item
         :param value: value for item
-        :param float expire: seconds until the key expires
+        :param float or None expire: seconds until the key expires
             (default None, no expiry)
         :param bool read: read value as bytes from file (default False)
-        :param str tag: text to associate with key (default None)
+        :param str or None tag: text to associate with key (default None)
         :param bool retry: retry if database timeout occurs (default False)
         :return: True if item was added
         :raises Timeout: if database timeout occurs
@@ -1425,12 +1425,12 @@ class Cache:
         'userids-500000000000000'
 
         :param value: value for item
-        :param str prefix: key prefix (default None, key is integer)
+        :param str or None prefix: key prefix (default None, key is integer)
         :param str side: either 'back' or 'front' (default 'back')
-        :param float expire: seconds until the key expires
+        :param float or None expire: seconds until the key expires
             (default None, no expiry)
         :param bool read: read value as bytes from file (default False)
-        :param str tag: text to associate with key (default None)
+        :param str or None tag: text to associate with key (default None)
         :param bool retry: retry if database timeout occurs (default False)
         :return: key for item in cache
         :raises Timeout: if database timeout occurs
@@ -1533,7 +1533,7 @@ class Cache:
         >>> value
         1234
 
-        :param str prefix: key prefix (default None, key is integer)
+        :param str or None prefix: key prefix (default None, key is integer)
         :param default: value to return if key is missing
             (default (None, None))
         :param str side: either 'front' or 'back' (default 'front')
@@ -1648,7 +1648,7 @@ class Cache:
         >>> value
         'c'
 
-        :param str prefix: key prefix (default None, key is integer)
+        :param str or None prefix: key prefix (default None, key is integer)
         :param default: value to return if key is missing
             (default (None, None))
         :param str side: either 'front' or 'back' (default 'front')
@@ -1848,11 +1848,11 @@ class Cache:
         TypeError: name cannot be callable
 
         :param cache: cache to store callable arguments and return values
-        :param str name: name given for callable (default None, automatic)
+        :param str or None name: name given for callable (default None, automatic)
         :param bool typed: cache different types separately (default False)
-        :param float expire: seconds until arguments expire
+        :param float or None expire: seconds until arguments expire
             (default None, no expiry)
-        :param str tag: text to associate with arguments (default None)
+        :param str or None tag: text to associate with arguments (default None)
         :param set ignore: positional or keyword args to ignore (default ())
         :return: callable decorator
 
@@ -2084,7 +2084,7 @@ class Cache:
         Raises :exc:`Timeout` error when database timeout occurs and `retry` is
         `False` (default).
 
-        :param float now: current time (default None, ``time.time()`` used)
+        :param float or None now: current time (default None, ``time.time()`` used)
         :param bool retry: retry if database timeout occurs (default False)
         :return: count of items removed
         :raises Timeout: if database timeout occurs

--- a/diskcache/djangocache.py
+++ b/diskcache/djangocache.py
@@ -48,7 +48,7 @@ class DjangoCache(BaseCache):
         """Return Deque with given `name` in subdirectory.
 
         :param str name: subdirectory name for Deque
-        :param maxlen: max length (default None, no max)
+        :param int or None maxlen: max length (default None, no max)
         :return: Deque with given name
 
         """
@@ -83,9 +83,9 @@ class DjangoCache(BaseCache):
         :param value: value for item
         :param float timeout: seconds until the item expires
             (default 300 seconds)
-        :param int version: key version number (default None, cache parameter)
+        :param int or None version: key version number (default None, cache parameter)
         :param bool read: read value as bytes from file (default False)
-        :param str tag: text to associate with key (default None)
+        :param str or None tag: text to associate with key (default None)
         :param bool retry: retry if database timeout occurs (default True)
         :return: True if item was added
 
@@ -110,7 +110,7 @@ class DjangoCache(BaseCache):
 
         :param key: key for item
         :param default: return value if key is missing (default None)
-        :param int version: key version number (default None, cache parameter)
+        :param int or None version: key version number (default None, cache parameter)
         :param bool read: if True, return file handle to value
             (default False)
         :param float expire_time: if True, return expire_time in tuple
@@ -128,7 +128,7 @@ class DjangoCache(BaseCache):
         """Return file handle corresponding to `key` from Cache.
 
         :param key: Python key to retrieve
-        :param int version: key version number (default None, cache parameter)
+        :param int or None version: key version number (default None, cache parameter)
         :return: file open for reading in binary mode
         :raises KeyError: if key is not found
 
@@ -153,9 +153,9 @@ class DjangoCache(BaseCache):
         :param value: value for item
         :param float timeout: seconds until the item expires
             (default 300 seconds)
-        :param int version: key version number (default None, cache parameter)
+        :param int or None version: key version number (default None, cache parameter)
         :param bool read: read value as bytes from file (default False)
-        :param str tag: text to associate with key (default None)
+        :param str or None tag: text to associate with key (default None)
         :param bool retry: retry if database timeout occurs (default True)
         :return: True if item was set
 
@@ -172,7 +172,7 @@ class DjangoCache(BaseCache):
         :param key: key for item
         :param float timeout: seconds until the item expires
             (default 300 seconds)
-        :param int version: key version number (default None, cache parameter)
+        :param int or None version: key version number (default None, cache parameter)
         :param bool retry: retry if database timeout occurs (default True)
         :return: True if key was touched
 
@@ -199,7 +199,7 @@ class DjangoCache(BaseCache):
 
         :param key: key for item
         :param default: return value if key is missing (default None)
-        :param int version: key version number (default None, cache parameter)
+        :param int or None version: key version number (default None, cache parameter)
         :param float expire_time: if True, return expire_time in tuple
             (default False)
         :param tag: if True, return tag in tuple (default False)
@@ -214,7 +214,7 @@ class DjangoCache(BaseCache):
         """Delete a key from the cache, failing silently.
 
         :param key: key for item
-        :param int version: key version number (default None, cache parameter)
+        :param int or None version: key version number (default None, cache parameter)
         :param bool retry: retry if database timeout occurs (default True)
         :return: True if item was deleted
 
@@ -238,8 +238,8 @@ class DjangoCache(BaseCache):
 
         :param key: key for item
         :param int delta: amount to increment (default 1)
-        :param int version: key version number (default None, cache parameter)
-        :param int default: value if key is missing (default None)
+        :param int or None version: key version number (default None, cache parameter)
+        :param int or None default: value if key is missing (default None)
         :param bool retry: retry if database timeout occurs (default True)
         :return: new value for item on success else None
         :raises ValueError: if key is not found and default is None
@@ -270,8 +270,8 @@ class DjangoCache(BaseCache):
 
         :param key: key for item
         :param int delta: amount to decrement (default 1)
-        :param int version: key version number (default None, cache parameter)
-        :param int default: value if key is missing (default None)
+        :param int or None version: key version number (default None, cache parameter)
+        :param int or None default: value if key is missing (default None)
         :param bool retry: retry if database timeout occurs (default True)
         :return: new value for item on success else None
         :raises ValueError: if key is not found and default is None
@@ -284,7 +284,7 @@ class DjangoCache(BaseCache):
         """Returns True if the key is in the cache and has not expired.
 
         :param key: key for item
-        :param int version: key version number (default None, cache parameter)
+        :param int or None version: key version number (default None, cache parameter)
         :return: True if key is found
 
         """
@@ -403,12 +403,12 @@ class DjangoCache(BaseCache):
         Remember to call memoize when decorating a callable. If you forget,
         then a TypeError will occur.
 
-        :param str name: name given for callable (default None, automatic)
+        :param str or None name: name given for callable (default None, automatic)
         :param float timeout: seconds until the item expires
             (default 300 seconds)
-        :param int version: key version number (default None, cache parameter)
+        :param int or None version: key version number (default None, cache parameter)
         :param bool typed: cache different types separately (default False)
-        :param str tag: text to associate with arguments (default None)
+        :param str or None tag: text to associate with arguments (default None)
         :param set ignore: positional or keyword args to ignore (default ())
         :return: callable decorator
 

--- a/diskcache/fanout.py
+++ b/diskcache/fanout.py
@@ -21,7 +21,7 @@ class FanoutCache:
     ):
         """Initialize cache instance.
 
-        :param str directory: cache directory
+        :param str or None directory: cache directory
         :param int shards: number of shards to distribute writes
         :param float timeout: SQLite connection timeout
         :param disk: `Disk` instance for serialization
@@ -110,10 +110,10 @@ class FanoutCache:
 
         :param key: key for item
         :param value: value for item
-        :param float expire: seconds until the key expires
+        :param float or None expire: seconds until the key expires
             (default None, no expiry)
         :param bool read: read value as raw bytes from file (default False)
-        :param str tag: text to associate with key (default None)
+        :param str or None tag: text to associate with key (default None)
         :param bool retry: retry if database timeout occurs (default False)
         :return: True if item was set
 
@@ -145,7 +145,7 @@ class FanoutCache:
         `True` (default `False`).
 
         :param key: key for item
-        :param float expire: seconds until the key expires
+        :param float or None expire: seconds until the key expires
             (default None, no expiry)
         :param bool retry: retry if database timeout occurs (default False)
         :return: True if key was touched
@@ -174,10 +174,10 @@ class FanoutCache:
 
         :param key: key for item
         :param value: value for item
-        :param float expire: seconds until the key expires
+        :param float or None expire: seconds until the key expires
             (default None, no expiry)
         :param bool read: read value as bytes from file (default False)
-        :param str tag: text to associate with key (default None)
+        :param str or None tag: text to associate with key (default None)
         :param bool retry: retry if database timeout occurs (default False)
         :return: True if item was added
 
@@ -592,7 +592,7 @@ class FanoutCache:
 
         :param str name: subdirectory name for Cache
         :param float timeout: SQLite connection timeout
-        :param disk: Disk type or subclass for serialization
+        :param Disk or None disk: Disk type or subclass for serialization
         :param settings: any of DEFAULT_SETTINGS
         :return: Cache with given name
 
@@ -627,7 +627,7 @@ class FanoutCache:
         1
 
         :param str name: subdirectory name for Deque
-        :param maxlen: max length (default None, no max)
+        :param int or None maxlen: max length (default None, no max)
         :return: Deque with given name
 
         """

--- a/diskcache/persistent.py
+++ b/diskcache/persistent.py
@@ -82,7 +82,8 @@ class Deque(Sequence):
         will *not* be automatically removed.
 
         :param iterable: iterable of items to append to deque
-        :param directory: deque directory (default None)
+        :param str or None directory: deque directory (default None)
+        :param int or None maxlen: max length (default None, no max)
 
         """
         self._cache = Cache(directory, eviction_policy='none')
@@ -106,6 +107,7 @@ class Deque(Sequence):
 
         :param Cache cache: cache to use
         :param iterable: iterable of items
+        :param int or None maxlen: max length (default None, no max)
         :return: initialized Deque
 
         """
@@ -953,7 +955,7 @@ class Index(MutableMapping):
         'fruit-500000000000000'
 
         :param value: value for item
-        :param str prefix: key prefix (default None, key is integer)
+        :param str or None prefix: key prefix (default None, key is integer)
         :param str side: either 'back' or 'front' (default 'back')
         :return: key for item in cache
 
@@ -991,7 +993,7 @@ class Index(MutableMapping):
         >>> index.pull(prefix='fruit')
         (None, None)
 
-        :param str prefix: key prefix (default None, key is integer)
+        :param str or None prefix: key prefix (default None, key is integer)
         :param default: value to return if key is missing
             (default (None, None))
         :param str side: either 'front' or 'back' (default 'front')
@@ -1200,7 +1202,7 @@ class Index(MutableMapping):
             ...
         TypeError: name cannot be callable
 
-        :param str name: name given for callable (default None, automatic)
+        :param str or None name: name given for callable (default None, automatic)
         :param bool typed: cache different types separately (default False)
         :param set ignore: positional or keyword args to ignore (default ())
         :return: callable decorator

--- a/diskcache/recipes.py
+++ b/diskcache/recipes.py
@@ -407,9 +407,9 @@ def memoize_stampede(
 
     :param cache: cache to store callable arguments and return values
     :param float expire: seconds until arguments expire
-    :param str name: name given for callable (default None, automatic)
+    :param str or None name: name given for callable (default None, automatic)
     :param bool typed: cache different types separately (default False)
-    :param str tag: text to associate with arguments (default None)
+    :param str or None tag: text to associate with arguments (default None)
     :param set ignore: positional or keyword args to ignore (default ())
     :return: callable decorator
 


### PR DESCRIPTION
## 📝 Description

Docstrings across the cache modules were overly strict about parameter types, omitting that several values—such as `expire`, `tag`, or `directory` could legitimately be None. This led to confusing type-hint warnings. The updated docstrings explicitly document optional None values throughout the core, fanout, Django cache, persistent cache, and recipe helpers, ensuring the documentation matches actual behavior.


## ✨ Changes


- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔒 Security update
